### PR TITLE
Feature/subscription group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2235,9 +2235,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "optional": true
     },
     "function-bind": {

--- a/src/model/core/Module.ts
+++ b/src/model/core/Module.ts
@@ -183,6 +183,7 @@ export class Module extends (EventEmitter as new() => ModuleEmitter) {
         await this.connection.connect();
         await this.subscribeToAllVariables();
         await this.subscribeToAllServices();
+        await this.connection.startListening();
         this.logger.info(`[${this.id}] Successfully subscribed to ${this.connection.monitoredItemSize()} assemblies`);
     }
 

--- a/src/model/core/Module.ts
+++ b/src/model/core/Module.ts
@@ -181,9 +181,11 @@ export class Module extends (EventEmitter as new() => ModuleEmitter) {
 
     public async connect() {
         await this.connection.connect();
-        await this.subscribeToAllVariables();
-        await this.subscribeToAllServices();
+
+        const pv = this.subscribeToAllVariables();
+        const pa = this.subscribeToAllServices();
         await this.connection.startListening();
+        await Promise.all([pv, pa]);
         this.logger.info(`[${this.id}] Successfully subscribed to ${this.connection.monitoredItemSize()} assemblies`);
     }
 
@@ -350,7 +352,7 @@ export class Module extends (EventEmitter as new() => ModuleEmitter) {
                 })
                 .on('parameterChanged', (data) => {
                     this.logger.debug(`[${this.id}] parameter changed: ` +
-                        `${data.strategy.name}.${data.parameter} = ${data.parameter.value}`);
+                        `${data.strategy.name}.${data.parameter.name} = ${data.parameter.value}`);
                     const entry: ParameterChange = {
                         timestampModule: data.parameter.timestamp,
                         service: service,

--- a/src/model/core/OpcUaConnection.ts
+++ b/src/model/core/OpcUaConnection.ts
@@ -152,6 +152,7 @@ export class  OpcUaConnection extends (EventEmitter as new() => OpcUaConnectionE
     }
 
     public addOpcUaNode(nodeId: string, namespaceUrl?: string) {
+        //console.log('add', nodeId, namespaceUrl)
         let nodeIdResolved;
         if (namespaceUrl) {
             nodeIdResolved = this.resolveNodeId(nodeId, namespaceUrl);
@@ -182,10 +183,10 @@ export class  OpcUaConnection extends (EventEmitter as new() => OpcUaConnectionE
         monitoredItemGroup.on('initialized', () => console.log('initialized'))
             .on('err', (msg) => console.log('err', msg))
             .on('changed', (monitoredItem: ClientMonitoredItemBase, dataValue: DataValue) => {
-                this.eventEmitter.emit(monitoredItem.itemToMonitor.nodeId.toString(), dataValue.value);
-                this.logger.info(`[${this.id}] ${monitoredItem.itemToMonitor.nodeId} changed to ${dataValue.value}`);
+                this.logger.trace(`[${this.id}] ${monitoredItem.itemToMonitor.nodeId.toString()} changed to ${dataValue}`);
+                this.eventEmitter.emit(monitoredItem.itemToMonitor.nodeId.toString(), dataValue);
             });
-        await monitoredItemGroup.setMonitoringMode(MonitoringMode.Reporting);
+        monitoredItemGroup.setMonitoringMode(MonitoringMode.Reporting);
         return this.eventEmitter;
     }
 

--- a/src/model/core/OpcUaConnection.ts
+++ b/src/model/core/OpcUaConnection.ts
@@ -31,6 +31,7 @@ import {
     ClientSubscription,
     coerceNodeId,
     DataValue,
+    MonitoringMode,
     OPCUAClient,
     TimestampsToReturn,
     UserIdentityInfo,
@@ -39,6 +40,7 @@ import {
     Variant,
     VariantArrayType
 } from 'node-opcua';
+import {ClientMonitoredItemGroup} from 'node-opcua-client/source/client_monitored_item_group';
 import {timeout} from 'promise-timeout';
 import StrictEventEmitter from 'strict-event-emitter-types';
 import {Category} from 'typescript-logging';
@@ -67,10 +69,11 @@ export class  OpcUaConnection extends (EventEmitter as new() => OpcUaConnectionE
 
     public readonly endpoint: string;
     public readonly id: string;
+    public readonly eventEmitter: EventEmitter;
     private session: ClientSession;
     private client: OPCUAClient;
     private subscription: ClientSubscription;
-    private readonly monitoredItems: Map<string, ClientMonitoredItemBase>;
+    private readonly items: Map<string, string>;
     private namespaceArray: string[];
     private readonly logger: Category;
     private readonly username: string;
@@ -81,9 +84,10 @@ export class  OpcUaConnection extends (EventEmitter as new() => OpcUaConnectionE
         this.id = moduleId;
         this.endpoint = endpoint;
         this.logger = catOpc;
-        this.monitoredItems = new Map<string, ClientMonitoredItemBase>();
         this.username = username;
         this.password = password;
+        this.eventEmitter = new EventEmitter();
+        this.items = new Map<string, string>();
     }
 
     /**
@@ -130,7 +134,7 @@ export class  OpcUaConnection extends (EventEmitter as new() => OpcUaConnectionE
             await timeout(this.client.disconnect(), 1000);
             this.client = undefined;
         }
-        this.monitoredItems.clear();
+        this.items.clear();
         this.logger.info(`[${this.id}] OPC UA connection disconnected`);
     }
 
@@ -147,31 +151,42 @@ export class  OpcUaConnection extends (EventEmitter as new() => OpcUaConnectionE
         return await this.session.readVariableValue(nodeIdResolved);
     }
 
-    public async listenToOpcUaNode(nodeId: string,
-                                   namespaceUrl: string,
-                                   samplingInterval = 100): Promise<ClientMonitoredItemBase> {
-        const nodeIdResolved = this.resolveNodeId(nodeId, namespaceUrl);
-        const monitoredItemKey = nodeIdResolved.toString();
-        if (this.monitoredItems.has(monitoredItemKey)) {
-            return this.monitoredItems.get(monitoredItemKey);
+    public addOpcUaNode(nodeId: string, namespaceUrl?: string) {
+        let nodeIdResolved;
+        if (namespaceUrl) {
+            nodeIdResolved = this.resolveNodeId(nodeId, namespaceUrl);
         } else {
-            const monitoredItem = await this.subscription.monitor({
-                    nodeId: nodeIdResolved,
-                    attributeId: AttributeIds.Value
-                },
-                {
-                    samplingInterval,
-                    discardOldest: true,
-                    queueSize: 1
-                }, TimestampsToReturn.Both);
-
-            if (monitoredItem.statusCode.value !== 0) {
-                throw new Error(monitoredItem.statusCode.description);
-            }
-            this.logger.debug(`[${this.id}] subscribed to opc ua Variable ${monitoredItemKey} `);
-            this.monitoredItems.set(monitoredItemKey, monitoredItem);
-            return monitoredItem;
+            nodeIdResolved = nodeId;
         }
+
+        const monitoredItemKey = nodeIdResolved.toString();
+        this.items.set(nodeId, monitoredItemKey);
+        return monitoredItemKey;
+    }
+
+    public async startListening(samplingInterval = 100): Promise<EventEmitter> {
+        const options = Array.from(this.items.values()).map((item) => {
+            return {
+                nodeId: item,
+                attributeId: AttributeIds.Value
+            };
+        });
+        const monitoredItemGroup: ClientMonitoredItemGroup = await this.subscription.monitorItems(
+            options,
+            {
+                samplingInterval,
+                discardOldest: true,
+                queueSize: 10
+            }, TimestampsToReturn.Both)
+        ;
+        monitoredItemGroup.on('initialized', () => console.log('initialized'))
+            .on('err', (msg) => console.log('err', msg))
+            .on('changed', (monitoredItem: ClientMonitoredItemBase, dataValue: DataValue) => {
+                this.eventEmitter.emit(monitoredItem.itemToMonitor.nodeId.toString(), dataValue.value);
+                this.logger.info(`[${this.id}] ${monitoredItem.itemToMonitor.nodeId} changed to ${dataValue.value}`);
+            });
+        await monitoredItemGroup.setMonitoringMode(MonitoringMode.Reporting);
+        return this.eventEmitter;
     }
 
     public async writeOpcUaNode(nodeId: string, namespaceUrl: string, value: number | string | boolean, dataType) {
@@ -193,7 +208,7 @@ export class  OpcUaConnection extends (EventEmitter as new() => OpcUaConnectionE
     }
 
     public monitoredItemSize(): number {
-        return this.monitoredItems.size;
+        return this.items.size;
     }
 
     /**
@@ -220,7 +235,7 @@ export class  OpcUaConnection extends (EventEmitter as new() => OpcUaConnectionE
     private async readNameSpaceArray() {
         const result: DataValue = await this.session.readVariableValue('ns=0;i=2255');
         const namespaceArray = result.value.value;
-        this.logger.debug(`[${this.id}] Got namespace array: ${JSON.stringify(namespaceArray)}`);
+        this.logger.info(`[${this.id}] Got namespace array: ${JSON.stringify(namespaceArray)}`);
         return namespaceArray;
     }
 

--- a/src/model/core/OpcUaConnection.ts
+++ b/src/model/core/OpcUaConnection.ts
@@ -152,7 +152,6 @@ export class  OpcUaConnection extends (EventEmitter as new() => OpcUaConnectionE
     }
 
     public addOpcUaNode(nodeId: string, namespaceUrl?: string) {
-        //console.log('add', nodeId, namespaceUrl)
         let nodeIdResolved;
         if (namespaceUrl) {
             nodeIdResolved = this.resolveNodeId(nodeId, namespaceUrl);
@@ -180,13 +179,11 @@ export class  OpcUaConnection extends (EventEmitter as new() => OpcUaConnectionE
                 queueSize: 10
             }, TimestampsToReturn.Both)
         ;
-        monitoredItemGroup.on('initialized', () => console.log('initialized'))
-            .on('err', (msg) => console.log('err', msg))
-            .on('changed', (monitoredItem: ClientMonitoredItemBase, dataValue: DataValue) => {
+        monitoredItemGroup.on('changed', (monitoredItem: ClientMonitoredItemBase, dataValue: DataValue) => {
                 this.logger.trace(`[${this.id}] ${monitoredItem.itemToMonitor.nodeId.toString()} changed to ${dataValue}`);
                 this.eventEmitter.emit(monitoredItem.itemToMonitor.nodeId.toString(), dataValue);
             });
-        monitoredItemGroup.setMonitoringMode(MonitoringMode.Reporting);
+        await monitoredItemGroup.setMonitoringMode(MonitoringMode.Reporting);
         return this.eventEmitter;
     }
 

--- a/src/model/dataAssembly/DataAssembly.ts
+++ b/src/model/dataAssembly/DataAssembly.ts
@@ -96,7 +96,7 @@ export class DataAssembly extends EventEmitter {
                         dataItem.namespaceIndex)
                     .map(([key, dataItem]: [string, OpcUaDataItem<any>]) => {
                         dataItem.on('changed', () => {
-                            catDataAssembly.debug(`Emit ${this.name}.${key} = ${dataItem.value}`);
+                            catDataAssembly.trace(`Emit ${this.name}.${key} = ${dataItem.value}`);
                             this.emit(key, dataItem);
                             this.emit('changed');
                         });

--- a/src/model/dataAssembly/DataItem.ts
+++ b/src/model/dataAssembly/DataItem.ts
@@ -105,16 +105,16 @@ export class OpcUaDataItem<T> extends DataItem<T> {
 
     public async subscribe(samplingInterval = 1000): Promise<OpcUaDataItem<T>> {
         if (this.value === undefined) {
-            await this.read();
+            //await this.read();
         }
-        const monitoredItem = await timeout(
-            this.connection.listenToOpcUaNode(this.nodeId, this.namespaceIndex, samplingInterval), 2000);
-        monitoredItem.on('changed', (dataValue) => {
-            this.logger.debug(`[${this.connection.id}] Variable Changed (${this.nodeId}) ` +
-                `= ${dataValue.value.value.toString()}`);
-            this.value = dataValue.value.value;
-            this.timestamp = dataValue.serverTimestamp;
-            this.emit('changed', {value: this.value, timestamp: this.timestamp});
+        this.connection.addOpcUaNode(this.namespaceIndex, this.nodeId);
+        this.connection.eventEmitter.on(this.nodeId,
+            (dataValue) => {
+                this.logger.debug(`[${this.connection.id}] Variable Changed (${this.nodeId}) ` +
+                    `= ${dataValue.value.value.toString()}`);
+                this.value = dataValue.value.value;
+                this.timestamp = dataValue.serverTimestamp;
+                this.emit('changed', {value: this.value, timestamp: this.timestamp});
         });
         this.logger.debug(`subscribed to Data Item ${this.nodeId}`);
         return this;

--- a/src/moduleTestServer/ModuleTestNumericVariable.ts
+++ b/src/moduleTestServer/ModuleTestNumericVariable.ts
@@ -105,7 +105,7 @@ export class TestServerNumericVariable extends TestServerVariable {
                 },
                 set: (variant) => {
                     this.vext = parseFloat(variant.value);
-                    catTestServer.debug(`Set Vext of ${this.name} to ${variant.value} -> ${this.vext}`);
+                    catTestServer.debug(`Set VExt of ${this.name} to ${variant.value} -> ${this.vext}`);
                     setTimeout(() => {
                         this.v = this.vext;
                     }, 500);
@@ -123,9 +123,9 @@ export class TestServerNumericVariable extends TestServerVariable {
         const amplitude = this.sclMax - this.sclMin;
         const average = (this.sclMax + this.sclMin) / 2;
         this.interval = global.setInterval(() => {
-            time = time + 0.05;
-            this.v = average + 0.5 * amplitude * Math.sin(2 * f1 * time + 3 * f2);
-        }, 100);
+            time = time + 0.5;
+            this.v = average + 0.5 * amplitude * Math.sin(0.01 * (1 + f1) * time + Math.PI * f2);
+        }, 500);
     }
 
     public stopRandomOscillation() {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -47,7 +47,7 @@ export default class Routes {
 
         // Error handling
         app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
-            catServer.error(`Internal server error (HTTP 500): ${err.toString()}`, err);
+            catServer.warn(`Internal server error (HTTP 500): ${err.toString()}`);
             res.status(500).send({ status: 'error', error: err.toString(), stack: err.stack });
         });
 

--- a/test/model/Manager.spec.ts
+++ b/test/model/Manager.spec.ts
@@ -161,8 +161,7 @@ describe('Manager', () => {
             const service1 = module.services[0];
             const service2 = module.services[1];
 
-            module.connect();
-            await service2.waitForStateChangeWithTimeout('IDLE', 2000);
+            await module.connect();
             service2.executeCommand(ServiceCommand.start);
             await service2.waitForStateChangeWithTimeout('EXECUTE');
 
@@ -197,8 +196,7 @@ describe('Manager', () => {
             const module = manager.modules[0];
             const service = module.services[1];
 
-            module.connect();
-            await service.waitForStateChangeWithTimeout('IDLE', 2000);
+            await module.connect();
             service.executeCommand(ServiceCommand.start);
             await service.waitForStateChangeWithTimeout('EXECUTE');
 

--- a/test/model/core/OpcUaConnection.spec.ts
+++ b/test/model/core/OpcUaConnection.spec.ts
@@ -80,11 +80,11 @@ describe('OpcUaConnection', () => {
             await connection.connect();
             expect(connection.isConnected()).to.equal(true);
 
-            const result = await connection.listenToOpcUaNode('Service1.CurrentTime.Text', 'urn:NodeOPCUA-Server-default');
-            expect(result.statusCode.value).to.equal(0);
-            expect(result.statusCode.description).to.equal('No Error');
+            const eventName = connection.addOpcUaNode('Service1.CurrentTime.Text', 'urn:NodeOPCUA-Server-default');
+            expect(eventName).to.equal('ns=1;s=Service1.CurrentTime.Text');
 
-            await new Promise((resolve) => result.on('changed', resolve));
+            const eventEmitter = await connection.startListening();
+            await new Promise((resolve) => eventEmitter.on(eventName, resolve));
 
             await connection.disconnect();
         });
@@ -96,23 +96,24 @@ describe('OpcUaConnection', () => {
             await connection.connect();
             expect(connection.isConnected()).to.equal(true);
 
-            const firstListener = await connection.listenToOpcUaNode(
+            const eventName1 = connection.addOpcUaNode(
                 'Service1.CurrentTime.Text', 'urn:NodeOPCUA-Server-default');
-            expect(firstListener.statusCode.value).to.equal(0);
-            expect(firstListener.statusCode.description).to.equal('No Error');
+            await connection.startListening();
+
             expect(connection.monitoredItemSize()).to.equal(1);
 
-            await new Promise((resolve) => firstListener.on('changed', resolve));
+            await new Promise((resolve) => connection.eventEmitter.on(eventName1, resolve));
 
             await connection.disconnect();
             expect(connection.monitoredItemSize()).to.equal(0);
             await connection.connect();
 
-            const secondListener = await connection.listenToOpcUaNode(
+            const eventName2 = connection.addOpcUaNode(
                 'Service1.CurrentTime.Text', 'urn:NodeOPCUA-Server-default');
+            expect(eventName1).to.equal(eventName2);
+            await connection.startListening();
             await new Promise((resolve, reject) => {
-                firstListener.on('changed', reject);
-                secondListener.on('changed', resolve);
+                connection.eventEmitter.on(eventName1, resolve);
             });
             expect(connection.monitoredItemSize()).to.equal(1);
         });
@@ -124,25 +125,25 @@ describe('OpcUaConnection', () => {
             await connection.connect();
             expect(connection.isConnected()).to.equal(true);
 
-            await connection.listenToOpcUaNode('Service1.Offset.VExt', 'urn:NodeOPCUA-Server-default');
+            connection.addOpcUaNode('Service1.Offset.VExt', 'urn:NodeOPCUA-Server-default');
             expect(connection.monitoredItemSize()).equals(1);
 
-            await connection.listenToOpcUaNode('Service1.Offset.VExt', 'urn:NodeOPCUA-Server-default');
+            connection.addOpcUaNode('Service1.Offset.VExt', 'urn:NodeOPCUA-Server-default');
             expect(connection.monitoredItemSize()).equals(1);
 
-            await expect(connection.listenToOpcUaNode('notexistant', 'urn:NodeOPCUA-Server-default'))
-                .to.be.rejectedWith('does not exist');
-            expect(connection.monitoredItemSize()).equals(1);
+            connection.addOpcUaNode('notexistant', 'urn:NodeOPCUA-Server-default');
 
-            await expect(connection.listenToOpcUaNode('notexistant', 'urn:nan'))
-                .to.be.rejectedWith('Could not resolve namespace');
-            expect(connection.monitoredItemSize()).equals(1);
 
-            await connection.listenToOpcUaNode('Service1.OpMode', 'urn:NodeOPCUA-Server-default');
             expect(connection.monitoredItemSize()).equals(2);
 
-            await connection.disconnect();
+            expect(() => connection.addOpcUaNode('notexistant', 'urn:nan'))
+                .to.throw('Could not resolve namespace');
+            expect(connection.monitoredItemSize()).equals(2);
 
+            connection.addOpcUaNode('Service1.OpMode', 'urn:NodeOPCUA-Server-default');
+            expect(connection.monitoredItemSize()).equals(3);
+            await connection.startListening();
+            await connection.disconnect();
         }).timeout(50000);
 
         it('should connect with username and password', async () => {

--- a/test/model/dataAssembly/DataItem.spec.ts
+++ b/test/model/dataAssembly/DataItem.spec.ts
@@ -132,10 +132,12 @@ describe('DataItem', () => {
                     data_type: 'String'
                 }, connection, 'write', 'string');
 
-            const a = await di.subscribe();
-            expect(di.value).to.equal('initial value');
+            di.subscribe();
 
-            await new Promise((resolve) => a.on('changed', resolve));
+            connection.startListening();
+
+            await new Promise((resolve) => di.on('changed', resolve));
+            expect(di.value).to.equal('initial value');
         });
 
         it('should subscribe, disconnect and resubscribe', async () => {
@@ -146,14 +148,17 @@ describe('DataItem', () => {
                     data_type: 'String'
                 }, connection, 'write', 'string');
 
-            const a = await di.subscribe();
-            await new Promise((resolve) => a.on('changed', resolve));
+            di.subscribe();
+
+            connection.startListening();
+            await new Promise((resolve) => di.on('changed', resolve));
 
             await connection.disconnect();
             await connection.connect();
 
-            const a1 = await di.subscribe();
-            await new Promise((resolve) => a1.on('changed', resolve));
+            di.subscribe();
+            connection.startListening();
+            await new Promise((resolve) => di.on('changed', resolve));
         });
 
         it('should write', async () => {

--- a/test/model/recipe/Parameter.spec.ts
+++ b/test/model/recipe/Parameter.spec.ts
@@ -200,18 +200,18 @@ describe('Parameter', () => {
                 value: '2 * ModuleTestServer.Variable001.V'
             }, [module]);
             expect(param.scopeArray[0].dataAssembly.listenerCount('changed')).to.equal(0);
-            expect(param.scopeArray[0].dataItem.listenerCount('changed')).to.equal(1);
+            expect(param.scopeArray[0].dataItem.listenerCount('changed')).to.equal(2);
 
             param.listenToScopeArray();
             param.listenToScopeArray();
             param.listenToScopeArray();
             param.listenToScopeArray();
             expect(param.scopeArray[0].dataAssembly.listenerCount('changed')).to.equal(1);
-            expect(param.scopeArray[0].dataItem.listenerCount('changed')).to.equal(1);
+            expect(param.scopeArray[0].dataItem.listenerCount('changed')).to.equal(2);
 
             param.unlistenToScopeArray();
             expect(param.scopeArray[0].dataAssembly.listenerCount('changed')).to.equal(0);
-            expect(param.scopeArray[0].dataItem.listenerCount('changed')).to.equal(1);
+            expect(param.scopeArray[0].dataItem.listenerCount('changed')).to.equal(2);
         });
 
     });


### PR DESCRIPTION
Use OPC UA subscription group for all OPC UA items instead of adding each item separately to subscription. This improves performance a lot since fewer OPC UA requests has to be sent (speedup of 30 seconds for all tests). Also the OPC UA test server is happier with it - no warnings anymore.

`OPCUAConnection` now emits all OPC UA data changes as events named as the respective OPC UA node id